### PR TITLE
Allow id without namespace

### DIFF
--- a/csv-parser.js
+++ b/csv-parser.js
@@ -3,15 +3,15 @@ var Config = require(path.resolve(process.cwd(), process.argv[2]));
 
 module.exports = {
     processCsv: processCsv
-}
+};
 
 function processCsv(fileContents) {
     if (!fileContents) {
         return {};
     }
-    var results = [];
+    var results;
     var regex = new RegExp('([^' + Config.csvEol + ']*)' + Config.csvEol, 'g');
-    
+
     for (var i = 0; i < Config.csvEolAlt.length; i++) {
         fileContents = fileContents.split(Config.csvEolAlt[i]).join(Config.csvEol);
     }
@@ -23,26 +23,33 @@ function processCsv(fileContents) {
     for (var j = 0; j < languages.length; j++) {
         to[languages[j]] = {};
     }
-    
+
     while ((results = regex.exec(fileContents)) !== null) {
         for (var str in Config.jsonReplace) {
             if (Config.jsonReplace.hasOwnProperty(str)) {
                 results[1] = results[1].replace(new RegExp(str, 'g'), Config.jsonReplace[str]);
             }
         }
-        
+
         var translations = results[1].split(Config.csvFieldSeparator);
-        var nss = translations[0].slice(0, translations[0].lastIndexOf('.')).split('.');
-        var id = translations[0].slice(translations[0].lastIndexOf('.') + 1);
+        var id = translations[0];
+        var dotIndex = id.lastIndexOf('.');
+        var nss;
+        if (dotIndex === -1) {
+            nss = [];
+        } else {
+            nss = id.slice(0, dotIndex).split('.');
+            id = id.slice(dotIndex + 1);
+        }
         translations.shift();
         for (var languageIndex = 0; languageIndex < languages.length; languageIndex++) {
             var currentPointer = to[languages[languageIndex]];
-            
+
             for (var nsIndex = 0; nsIndex < nss.length; nsIndex++) {
                 if (currentPointer[nss[nsIndex]] === undefined) {
                     currentPointer[nss[nsIndex]] = {};
                 }
-                
+
                 currentPointer = currentPointer[nss[nsIndex]];
             }
 
@@ -51,6 +58,6 @@ function processCsv(fileContents) {
             }
         }
     }
-    
+
     return to;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-translate-csv",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "A CLI build tool to generate JSON files required by Angular Translate from a single CSV file",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Currently, only namespaced ids are supported, i.e like "foo.bar".

This pull request allows to have ids without dots. The corresponding messages will appear at the root of the generated JSON object.